### PR TITLE
[Slurm] Fix error description on multiple parallel tasks with more than one step error.

### DIFF
--- a/pkg/parser/slurm.go
+++ b/pkg/parser/slurm.go
@@ -232,7 +232,7 @@ func SlurmValidateAndReplaceScript(script string, nTasks int32) (string, error) 
 		}
 
 		if nTasks > 1 && srunCount > 0 {
-			return "", errors.New("multiple parallel tasks with a task count greater than 1 are not supported yet")
+			return "", errors.New("multiple parallel tasks with more than one step are not supported yet")
 		}
 
 		if index := findCommand(line, srunCommand); index != -1 {

--- a/pkg/parser/slurm_test.go
+++ b/pkg/parser/slurm_test.go
@@ -270,7 +270,7 @@ srun -n 4 -c 1 my_program_4 &
 wait
 `,
 			nTasks:  8,
-			wantErr: "multiple parallel tasks with a task count greater than 1 are not supported yet",
+			wantErr: "multiple parallel tasks with more than one step are not supported yet",
 		},
 		"srun must specified at lease one argument": {
 			script:  "#!/bin/bash\nsrun",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix error description on multiple parallel tasks with more than one step error on Slurm mode.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```