### PR TITLE
Fix GPU resources handling for slurm commands 

### DIFF
--- a/pkg/builder/slurm_builder.go
+++ b/pkg/builder/slurm_builder.go
@@ -323,13 +323,6 @@ func (b *slurmBuilder) build(ctx context.Context) (runtime.Object, []runtime.Obj
 			totalCpus.Add(*b.cpusPerTask)
 		}
 
-		if b.gpusPerTask != nil {
-			for name, number := range b.gpusPerTask {
-				requests[corev1.ResourceName(name)] = *number
-			}
-			totalGpus.Add(totalGPUsPerTask)
-		}
-
 		if b.memPerTask != nil {
 			requests[corev1.ResourceMemory] = *b.memPerTask
 			totalMem.Add(*b.memPerTask)
@@ -352,6 +345,13 @@ func (b *slurmBuilder) build(ctx context.Context) (runtime.Object, []runtime.Obj
 		limits := corev1.ResourceList{}
 		if !memPerContainer.IsZero() {
 			limits[corev1.ResourceMemory] = memPerContainer
+		}
+
+		if b.gpusPerTask != nil {
+			for name, number := range b.gpusPerTask {
+				limits[corev1.ResourceName(name)] = *number
+			}
+			totalGpus.Add(totalGPUsPerTask)
 		}
 
 		if len(limits) > 0 {

--- a/pkg/cmd/create/create_test.go
+++ b/pkg/cmd/create/create_test.go
@@ -1781,8 +1781,10 @@ export $(cat /slurm/env/$JOB_CONTAINER_INDEX/slurm.env | xargs)cd /mydir
 								WithResources(corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
 										corev1.ResourceMemory: resource.MustParse("2G"),
-										"volta":               resource.MustParse("3"),
-										"kepler":              resource.MustParse("1"),
+									},
+									Limits: corev1.ResourceList{
+										"volta":  resource.MustParse("3"),
+										"kepler": resource.MustParse("1"),
 									},
 								}).
 								Obj()).
@@ -1791,8 +1793,10 @@ export $(cat /slurm/env/$JOB_CONTAINER_INDEX/slurm.env | xargs)cd /mydir
 								WithResources(corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
 										corev1.ResourceMemory: resource.MustParse("2G"),
-										"volta":               resource.MustParse("3"),
-										"kepler":              resource.MustParse("1"),
+									},
+									Limits: corev1.ResourceList{
+										"volta":  resource.MustParse("3"),
+										"kepler": resource.MustParse("1"),
 									},
 								}).
 								Obj()).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?


<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

This PR fixes GPU resources handling for slurm commands which set GPU resources as requests instead of limits. see 
[Schedule GPUs](https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/) for the explanation why GPUs should be set as limits.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed GPU resources handling for slurm commands which set GPU resources as requests instead of limits
```