### PR TITLE
Use testing.TB.Context() instead of context.Background().

### DIFF
--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -463,7 +463,7 @@ func TestBuilder(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 
 			tcg := cmdtesting.NewTestClientGetter().

--- a/pkg/builder/interactive_builder_test.go
+++ b/pkg/builder/interactive_builder_test.go
@@ -208,7 +208,7 @@ func TestInteractiveBuilder(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 
 			tcg := cmdtesting.NewTestClientGetter().

--- a/pkg/builder/job_builder_test.go
+++ b/pkg/builder/job_builder_test.go
@@ -209,7 +209,7 @@ func TestJobBuilder(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 
 			tcg := cmdtesting.NewTestClientGetter().

--- a/pkg/builder/ray_cluster_builder_test.go
+++ b/pkg/builder/ray_cluster_builder_test.go
@@ -221,7 +221,7 @@ func TestRayClusterBuilder(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 
 			tcg := cmdtesting.NewTestClientGetter().

--- a/pkg/builder/ray_job_builder_test.go
+++ b/pkg/builder/ray_job_builder_test.go
@@ -251,7 +251,7 @@ func TestRayJobBuilder(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 
 			tcg := cmdtesting.NewTestClientGetter().

--- a/pkg/builder/slurm_builder_test.go
+++ b/pkg/builder/slurm_builder_test.go
@@ -332,7 +332,7 @@ export $(cat /slurm/env/$JOB_CONTAINER_INDEX/slurm.env | xargs)
 				tc.beforeTest(t, &tc)
 			}
 
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 
 			tcg := cmdtesting.NewTestClientGetter().

--- a/pkg/cmd/create/create_interactive_test.go
+++ b/pkg/cmd/create/create_interactive_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package create
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/url"
@@ -229,7 +228,7 @@ func TestCreateOptionsRunInteractive(t *testing.T) {
 					tc.createMutation(pod)
 				}
 
-				_, err = k8sClientset.CoreV1().Pods(pod.GetNamespace()).Create(context.Background(), pod, metav1.CreateOptions{})
+				_, err = k8sClientset.CoreV1().Pods(pod.GetNamespace()).Create(t.Context(), pod, metav1.CreateOptions{})
 				if err != nil {
 					return true, nil, err
 				}
@@ -243,7 +242,7 @@ func TestCreateOptionsRunInteractive(t *testing.T) {
 				WithDynamicClient(dynamicClient).
 				WithRESTMapper(restMapper)
 
-			gotErr := tc.options.Run(context.Background(), tcg, testStartTime)
+			gotErr := tc.options.Run(t.Context(), tcg, testStartTime)
 
 			var gotErrStr string
 			if gotErr != nil {
@@ -254,7 +253,7 @@ func TestCreateOptionsRunInteractive(t *testing.T) {
 				t.Errorf("Unexpected error (-want/+got)\n%s", diff)
 			}
 
-			gotPodList, err := k8sClientset.CoreV1().Pods(metav1.NamespaceDefault).List(context.Background(), metav1.ListOptions{})
+			gotPodList, err := k8sClientset.CoreV1().Pods(metav1.NamespaceDefault).List(t.Context(), metav1.ListOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/cmd/create/create_job_test.go
+++ b/pkg/cmd/create/create_job_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package create
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -719,7 +718,7 @@ func TestCreateJobCmd(t *testing.T) {
 				}
 
 				unstructured, err := dynamicClient.Resource(mapping.Resource).Namespace(metav1.NamespaceDefault).
-					List(context.Background(), metav1.ListOptions{})
+					List(t.Context(), metav1.ListOptions{})
 				if err != nil {
 					t.Error(err)
 					return

--- a/pkg/cmd/create/create_raycluster_test.go
+++ b/pkg/cmd/create/create_raycluster_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package create
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -234,7 +233,7 @@ func TestCreateRayClusterCmd(t *testing.T) {
 				}
 
 				unstructured, err := dynamicClient.Resource(mapping.Resource).Namespace(metav1.NamespaceDefault).
-					List(context.Background(), metav1.ListOptions{})
+					List(t.Context(), metav1.ListOptions{})
 				if err != nil {
 					t.Error(err)
 					return

--- a/pkg/cmd/create/create_rayjob_test.go
+++ b/pkg/cmd/create/create_rayjob_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package create
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -368,7 +367,7 @@ func TestCreateRayJobCmd(t *testing.T) {
 				}
 
 				unstructured, err := dynamicClient.Resource(mapping.Resource).Namespace(metav1.NamespaceDefault).
-					List(context.Background(), metav1.ListOptions{})
+					List(t.Context(), metav1.ListOptions{})
 				if err != nil {
 					t.Error(err)
 					return

--- a/pkg/cmd/create/create_slurm_test.go
+++ b/pkg/cmd/create/create_slurm_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package create
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"regexp"
@@ -1297,7 +1296,7 @@ export $(cat /slurm/env/$JOB_CONTAINER_INDEX/slurm.env | xargs)cd /mydir
 				}
 
 				unstructured, err := dynamicClient.Resource(mapping.Resource).Namespace(metav1.NamespaceDefault).
-					List(context.Background(), metav1.ListOptions{})
+					List(t.Context(), metav1.ListOptions{})
 				if err != nil {
 					t.Error(err)
 					return

--- a/pkg/cmd/delete/delete_interactive_test.go
+++ b/pkg/cmd/delete/delete_interactive_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package delete
 
 import (
-	"context"
 	"slices"
 	"testing"
 
@@ -176,7 +175,7 @@ func TestInteractiveCmd(t *testing.T) {
 				t.Errorf("Unexpected error output (-want/+got)\n%s", diff)
 			}
 
-			gotInteractiveList, err := clientset.CoreV1().Pods(tc.ns).List(context.Background(), metav1.ListOptions{})
+			gotInteractiveList, err := clientset.CoreV1().Pods(tc.ns).List(t.Context(), metav1.ListOptions{})
 			if err != nil {
 				t.Error(err)
 				return

--- a/pkg/cmd/delete/delete_job_test.go
+++ b/pkg/cmd/delete/delete_job_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package delete
 
 import (
-	"context"
 	"slices"
 	"testing"
 
@@ -191,7 +190,7 @@ jobs.batch "j2" created in "Slurm" mode. Switch to the correct mode to delete it
 				t.Errorf("Unexpected error output (-want/+got)\n%s", diff)
 			}
 
-			gotJobList, err := clientset.BatchV1().Jobs(tc.ns).List(context.Background(), metav1.ListOptions{})
+			gotJobList, err := clientset.BatchV1().Jobs(tc.ns).List(t.Context(), metav1.ListOptions{})
 			if err != nil {
 				t.Error(err)
 				return

--- a/pkg/cmd/delete/delete_ray_cluster_test.go
+++ b/pkg/cmd/delete/delete_ray_cluster_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package delete
 
 import (
-	"context"
 	"slices"
 	"testing"
 
@@ -176,7 +175,7 @@ func TestRayClusterCmd(t *testing.T) {
 				t.Errorf("Unexpected error output (-want/+got)\n%s", diff)
 			}
 
-			gotRayClusterList, err := clientset.RayV1().RayClusters(tc.ns).List(context.Background(), metav1.ListOptions{})
+			gotRayClusterList, err := clientset.RayV1().RayClusters(tc.ns).List(t.Context(), metav1.ListOptions{})
 			if err != nil {
 				t.Error(err)
 				return

--- a/pkg/cmd/delete/delete_ray_job_test.go
+++ b/pkg/cmd/delete/delete_ray_job_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package delete
 
 import (
-	"context"
 	"slices"
 	"testing"
 
@@ -176,7 +175,7 @@ func TestRayJobCmd(t *testing.T) {
 				t.Errorf("Unexpected error output (-want/+got)\n%s", diff)
 			}
 
-			gotRayJobList, err := clientset.RayV1().RayJobs(tc.ns).List(context.Background(), metav1.ListOptions{})
+			gotRayJobList, err := clientset.RayV1().RayJobs(tc.ns).List(t.Context(), metav1.ListOptions{})
 			if err != nil {
 				t.Error(err)
 				return

--- a/pkg/cmd/delete/delete_slurm_test.go
+++ b/pkg/cmd/delete/delete_slurm_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package delete
 
 import (
-	"context"
 	"slices"
 	"testing"
 
@@ -191,7 +190,7 @@ jobs.batch "j2" created in "Job" mode. Switch to the correct mode to delete it
 				t.Errorf("Unexpected error output (-want/+got)\n%s", diff)
 			}
 
-			gotJobList, err := clientset.BatchV1().Jobs(tc.ns).List(context.Background(), metav1.ListOptions{})
+			gotJobList, err := clientset.BatchV1().Jobs(tc.ns).List(t.Context(), metav1.ListOptions{})
 			if err != nil {
 				t.Error(err)
 				return

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -50,5 +50,5 @@ var _ = ginkgo.BeforeSuite(func() {
 	cfg = util.GetConfigWithContext("")
 	k8sClient = util.CreateClient(cfg)
 	restClient = util.CreateRestClient(cfg)
-	ctx = context.Background()
+	ctx = ginkgo.GinkgoT().Context()
 })

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -73,7 +73,7 @@ func (f *Framework) SetupClient(cfg *rest.Config) (context.Context, client.Clien
 	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 	gomega.ExpectWithOffset(1, k8sClient).NotTo(gomega.BeNil())
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ginkgo.GinkgoT().Context())
 	f.cancel = cancel
 
 	return ctx, k8sClient


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Use testing.TB.Context() instead of context.Background().

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```