### PR TITLE
Fix Slurm entrypoint template whitespace so --chdir works

### DIFF
--- a/pkg/builder/templates/slurm_entrypoint_script.sh.tmpl
+++ b/pkg/builder/templates/slurm_entrypoint_script.sh.tmpl
@@ -12,6 +12,7 @@ SBATCH_JOB_NAME={{.SbatchJobName}}
 
 export $(cat {{.EnvsPath}}/{{.SlurmEnvFilename}} | xargs)
 
-{{- if .ChangeDir }}cd {{.ChangeDir}}{{end}}
+{{- if .ChangeDir }}
+cd {{.ChangeDir}}{{end}}
 
 {{.BuildEntrypointCommand}}

--- a/pkg/cmd/create/create_slurm_test.go
+++ b/pkg/cmd/create/create_slurm_test.go
@@ -471,7 +471,8 @@ fi
 
 SBATCH_JOB_NAME=job-name
 
-export $(cat /slurm/env/slurm.env | xargs)cd /mydir
+export $(cat /slurm/env/slurm.env | xargs)
+cd /mydir
 
 /slurm/scripts/script </home/%u/%x/stderr%%-%A-%a-%j-%N-%n-%t.out 1> >(tee /home/${USER_ID}/${SBATCH_JOB_NAME}/stdout%-${SLURM_ARRAY_JOB_ID}-${SLURM_ARRAY_TASK_ID}-${SLURM_JOB_ID}-${HOSTNAME}-${JOB_COMPLETION_INDEX}-${SLURM_ARRAY_TASK_ID}.out) 2> >(tee /home/${USER_ID}/${SBATCH_JOB_NAME}/stderr%-${SLURM_ARRAY_JOB_ID}-${SLURM_ARRAY_TASK_ID}-${SLURM_JOB_ID}-${HOSTNAME}-${JOB_COMPLETION_INDEX}-${SLURM_ARRAY_TASK_ID}.out >&2)
 `).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Remove the whitespace-trimming modifier from the `if .ChangeDir` block in the Slurm entrypoint template so the `cd` command is emitted
  on its own line. Without this change, providing `--chdir` causes the generated script to concatenate `cd` with the preceding `export`
  statement, triggering `/slurm/scripts/entrypoint.sh: export: '...': not a valid identifier`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```